### PR TITLE
Update instructions for Arch Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@ I got tired with semi-broken online keyboard testers, so here we go – one on a
 * Wayland is not supported
 
 ## Installation
-### AUR
-`paru -S kbt`
+### Arch Linux
+`pacman -S kbt`
 
 ### Cargo
 `cargo install kbt`


### PR DESCRIPTION
`kbt` is now available in the official repositories: <https://archlinux.org/packages/extra/x86_64/kbt/> 🥳
